### PR TITLE
build_fullurl tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,22 @@ OpenGraph URLs need to be absolute, including scheme and authority parts. Here's
     <meta property="og:image" content="{% fullstatic "cat.jpg" %}">
     
 
+Alternatively you can convert URL from relative to absolute using ``build_fullurl`` tag:
+
+.. code:: html+django
+
+    {% build_fullurl article.get_absolute_url %}
+    {% build_fullurl "/custom-url/" %}
+
+
+Or with sorl-thumbnail:
+
+.. code:: html+django
+
+    {% thumbnail article.image as thumb %}
+    {% build_fullurl thumb.url %}
+    {% endthumbnail %}
+
 See also
 ========
 

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Or with sorl-thumbnail:
 
 .. code:: html+django
 
-    {% thumbnail article.image as thumb %}
+    {% thumbnail article.image "100x100" as thumb %}
     {% build_fullurl thumb.url %}
     {% endthumbnail %}
 

--- a/fullurl/templatetags/fullurl.py
+++ b/fullurl/templatetags/fullurl.py
@@ -42,6 +42,22 @@ def fullstatic(parser, token):
     return FullStaticNode(do_static(parser, token))
 
 
+@register.simple_tag(takes_context=True)
+def build_fullurl(context, url):
+    """Converts relative URL to absolute.
+
+    For example:
+
+        {% build_fullurl article.get_absolute_url %}
+
+    or:
+
+        {% build_fullurl "/custom-url/" %}
+
+    """
+    return context.request.build_absolute_uri(url)
+
+
 class FullURLNode(Node):
     def __init__(self, subject):
         self._subject = subject

--- a/fullurl/tests.py
+++ b/fullurl/tests.py
@@ -45,3 +45,8 @@ class FullURLTestCase(TestCase):
         with self.settings(ROOT_URLCONF=__name__):
             rendered = template.render(self.request_context)
             self.assertEquals(rendered, 'http://testserver/foobar/welcome')
+
+    def test_build_fullurl_custom(self):
+        template = Template('{% load fullurl %}{% build_fullurl "/custom-url/" %}')
+        rendered = template.render(self.request_context)
+        self.assertEquals(rendered, 'http://testserver/custom-url/')


### PR DESCRIPTION
Custom tag that just converts relative url to absolute. 
For example you can reuse get_absolute_url methods or make full url for thumbnails.